### PR TITLE
Migrate Dockerfile to ROS2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ros:noetic-ros-core
+FROM osrf/ros:humble-desktop-full
 
 # Dev tools
 # Try to keep ROS-related dependencies out of here and inside package.xml to be installed with rosdep instead
@@ -26,29 +26,31 @@ RUN groupadd --gid $USER_GID $USERNAME \
 
 # Prepare to build the project
 ENV HOMEDIR=/home/${USERNAME}
-ENV CATKIN_WS=${HOMEDIR}/mcav_ws
-ENV SOURCE_DIR=${CATKIN_WS}/src/sd_vehicle_interface
-WORKDIR ${CATKIN_WS}
+ENV WORKSPACE=${HOMEDIR}/mcav_ws
+ENV SOURCE_DIR=${WORKSPACE}/src/sd_vehicle_interface
+WORKDIR ${WORKSPACE}
 COPY ./vehicle_interface/package.xml ${SOURCE_DIR}/vehicle_interface/package.xml
 # Project-specific dependency install
-RUN apt-get update && rosdep init && rosdep update && rosdep install --from-paths src --ignore-src -r -y \
+RUN rm /etc/ros/rosdep/sources.list.d/20-default.list
+RUN apt-get update \
+    && rosdep init \
+    && rosdep update \
+    && rosdep install --from-paths src --ignore-src -r -y \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 # Build project
 COPY . ${SOURCE_DIR}
-RUN /bin/bash -c '. /opt/ros/$ROS_DISTRO/setup.bash; cd ${CATKIN_WS}; catkin_make -DCMAKE_BUILD_TYPE=Release'
+RUN /bin/bash -c '. /opt/ros/$ROS_DISTRO/setup.bash; cd ${WORKSPACE}; colcon build'
 
 # Change owner of the files to non-root user
 RUN chown -R ${USERNAME} /home/${USERNAME}
 # Add source commands to bashrc
 RUN echo "source /opt/ros/$ROS_DISTRO/setup.bash" >> /home/${USERNAME}/.bashrc
-RUN echo "source ~/mcav_ws/devel/setup.bash" >> /home/${USERNAME}/.bashrc
+RUN echo "source ~/mcav_ws/install/setup.bash" >> /home/${USERNAME}/.bashrc
 # Change prompt to show we are in a docker container
 RUN echo "export PS1='\[\e]0;\u@docker: \w\a\]${debian_chroot:+($debian_chroot)}\[\033[01;32m\]\u@docker\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '" >> /home/${USERNAME}/.bashrc
 # Add tmux configuration file
 COPY docker/.tmux.conf /home/${USERNAME}/.tmux.conf
-
-RUN echo "127.0.0.1	`hostname`.localdomain	`hostname`" >> /etc/hosts
 
 WORKDIR ${SOURCE_DIR}
 CMD /bin/bash


### PR DESCRIPTION
This pull request updates the Dockerfile for using the SD-VehicleInterface in ROS 2 Humble. The changes include updating the base image to osrf/ros:humble-desktop-full, updating rosdep configuration, and using colcon build for building the project.