### PR TITLE
Fix swapped gear_status and hazard_lights_status report values

### DIFF
--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -479,11 +479,11 @@ int main(int argc, char **argv) {
     control_mode_status_pub->publish(current_control_mode_report);
 
     current_gear_status.stamp = node->get_clock()->now();
-    current_gear_status.report = target_hazard_lights_cmd;
+    current_gear_status.report = target_gear_cmd;
     gear_status_pub->publish(current_gear_status);
     
     current_hazard_lights_status.stamp = node->get_clock()->now();
-    current_hazard_lights_status.report = target_gear_cmd;
+    current_hazard_lights_status.report = target_hazard_lights_cmd;
     hazard_light_status_pub->publish(current_hazard_lights_status);
     
     current_indicator_status.stamp = node->get_clock()->now();


### PR DESCRIPTION
## Summary

- `gear_status.report` was incorrectly assigned `target_hazard_lights_cmd`, and `hazard_lights_status.report` was assigned `target_gear_cmd` — the two variables were swapped
- This caused Autoware to receive gear status with the hazard lights value and vice versa

## Changes

Two-line swap in `sd_vehicle_interface.cpp` (L482, L486):

```diff
- current_gear_status.report = target_hazard_lights_cmd;
+ current_gear_status.report = target_gear_cmd;

- current_hazard_lights_status.report = target_gear_cmd;
+ current_hazard_lights_status.report = target_hazard_lights_cmd;
```

## Testing

Verified in a Docker container (ROS 2 Humble + simulation mode):

1. Published `gear_cmd=2` (DRIVE) and `hazard_lights_cmd=1` (ENABLE)
2. Confirmed `gear_status.report=2` and `hazard_lights_status.report=1` — no cross-assignment

```
[PASS] gear_status has correct value
[PASS] hazard_lights_status has correct value
[RESULT] ALL TESTS PASSED — fix is verified!
```

Closes Monash-Connected-Autonomous-Vehicle/autoware#89