### PR TITLE
Logger Functionality and Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,19 +93,31 @@ Parameters
 | sd_speed_source    | {vehicle_can_speed, imu_speed, ndt_speed} | vehicle_can_speed | Input vehicle speed                        |
 | sd_simulation_mode | {true, false}                             | false             | Use on the car or on the Gazebo simulation |
 
-Logger Functionality (still testing)
+Logger Functionality 
 ------
-The default launch command is:
+
+The logging macros are defined in `sd_logger.h` and are mainly used inside `sd_vehicle_interface.cpp`.
+
+#### The default launch command is:
 ```
 source install/setup.bash
 ros2 launch sd_vehicle_interface sd_vehicle_interface.launch.xml sd_simulation_mode:=true
 ```
+#### Turning logger on/off:
 To toggle logger on or off before running, pass (append) in this ROS parameter to the launch command (set the value to true or false)
 ```
 sd_enable_logging:=false
 ```
-The logger functionality could also be toggled on or off even when the code is still running by:
+The logger functionality could also be toggled on or off at runtime by:
 ```
 ros2 param set /sd_vehicle_interface_node sd_enable_logging true
 ```
-
+#### Display different log levels:
+Different levels of logging can also be set using:
+```
+sd_logger_level:=warn
+```
+Or during runtime, the logging level display can be set using:
+```
+ros2 param set /sd_vehicle_interface_node sd_logger_level warn
+```

--- a/README.md
+++ b/README.md
@@ -92,3 +92,20 @@ Parameters
 | sd_gps_imu         | {oxts, peak, none}                        | oxts              | The GPS/IMU used                           |
 | sd_speed_source    | {vehicle_can_speed, imu_speed, ndt_speed} | vehicle_can_speed | Input vehicle speed                        |
 | sd_simulation_mode | {true, false}                             | false             | Use on the car or on the Gazebo simulation |
+
+Logger Functionality (still testing)
+------
+The default launch command is:
+```
+source install/setup.bash
+ros2 launch sd_vehicle_interface sd_vehicle_interface.launch.xml sd_simulation_mode:=true
+```
+To toggle logger on or off before running, pass (append) in this ROS parameter to the launch command (set the value to true or false)
+```
+sd_enable_logging:=false
+```
+The logger functionality could also be toggled on or off even when the code is still running by:
+```
+ros2 param set /sd_vehicle_interface_node sd_enable_logging true
+```
+

--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ Logger Functionality
 
 The logging macros are defined in `sd_logger.h` and are mainly used inside `sd_vehicle_interface.cpp`.
 
-#### The default launch command is:
+### The default launch command is:
 ```
 source install/setup.bash
 ros2 launch sd_vehicle_interface sd_vehicle_interface.launch.xml sd_simulation_mode:=true
 ```
-#### Turning logger on/off:
-To toggle logger on or off before running, pass (append) in this ROS parameter to the launch command (set the value to true or false)
+### Turning logger on/off:
+To toggle logger on or off before running, pass (append) in this ROS parameter to the launch command (set the value to true or false).
 ```
 sd_enable_logging:=false
 ```
@@ -112,7 +112,7 @@ The logger functionality could also be toggled on or off at runtime by:
 ```
 ros2 param set /sd_vehicle_interface_node sd_enable_logging true
 ```
-#### Display different log levels:
+### Display different log levels:
 Different levels of logging can also be set using:
 ```
 sd_logger_level:=warn

--- a/vehicle_interface/launch/sd_vehicle_interface.launch.xml
+++ b/vehicle_interface/launch/sd_vehicle_interface.launch.xml
@@ -3,12 +3,14 @@
   <arg name="sd_gps_imu" default="peak" description="The Gps or IMU, oxts or peak"/>
   <arg name="sd_speed_source" default="vehicle_can_speed" description="The source of vehicle speed used to close the control loop, (vehicle_can_speed, imu_speed or ndt_speed)"/>
   <arg name="sd_simulation_mode" default="false" description="Choose to launch the VI for control of a real vehicle or simulated vehicle, true for simulation (e.g Gazebo)"/>
+  <arg name="sd_logger_level" default="debug" description="Choose the severity level (debug, info, warn, error, or fatal) of the logger"/>
 
   <node pkg="sd_vehicle_interface" exec="sd_vehicle_interface_node" name="sd_vehicle_interface_node" output = "screen">
     	<param name="sd_vehicle" value="$(var sd_vehicle)" />
     	<param name="sd_gps_imu" value="$(var sd_gps_imu)" />
     	<param name="sd_speed_source" value="$(var sd_speed_source)" />
     	<param name="sd_simulation_mode" value="$(var sd_simulation_mode)" />
+    	<param name="sd_logger_level" value="$(var sd_logger_level)" />
   </node>
 
   <group unless="$(var sd_simulation_mode)">

--- a/vehicle_interface/launch/sd_vehicle_interface.launch.xml
+++ b/vehicle_interface/launch/sd_vehicle_interface.launch.xml
@@ -4,6 +4,7 @@
   <arg name="sd_speed_source" default="vehicle_can_speed" description="The source of vehicle speed used to close the control loop, (vehicle_can_speed, imu_speed or ndt_speed)"/>
   <arg name="sd_simulation_mode" default="false" description="Choose to launch the VI for control of a real vehicle or simulated vehicle, true for simulation (e.g Gazebo)"/>
   <arg name="sd_logger_level" default="debug" description="Choose the severity level (debug, info, warn, error, or fatal) of the logger"/>
+  <arg name="sd_enable_logging" default="true" description="Enable or disable application logging"/>
 
   <node pkg="sd_vehicle_interface" exec="sd_vehicle_interface_node" name="sd_vehicle_interface_node" output = "screen">
     	<param name="sd_vehicle" value="$(var sd_vehicle)" />
@@ -11,6 +12,7 @@
     	<param name="sd_speed_source" value="$(var sd_speed_source)" />
     	<param name="sd_simulation_mode" value="$(var sd_simulation_mode)" />
     	<param name="sd_logger_level" value="$(var sd_logger_level)" />
+    	<param name="sd_enable_logging" value="$(var sd_enable_logging)" />
   </node>
 
   <group unless="$(var sd_simulation_mode)">

--- a/vehicle_interface/src/sd_vehicle_interface/sd_control.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_control.cpp
@@ -182,7 +182,7 @@ namespace speedcontroller{
 
     }
 	
-		int8_t CalculateTorqueRequestEnv200(double TargetLinearVelocity_Mps, double CurrentLinearVelocity_Mps, int& P_Contribution_Pc, int& I_Contribution_Pc, int& D_Contribution_Pc, int& FF_Contribution_Pc){
+	int8_t CalculateTorqueRequestEnv200(double TargetLinearVelocity_Mps, double CurrentLinearVelocity_Mps, int& P_Contribution_Pc, int& I_Contribution_Pc, int& D_Contribution_Pc, int& FF_Contribution_Pc){
         
 		//Calculate PID Errors
 		static double LinearVelocityError_Mps;

--- a/vehicle_interface/src/sd_vehicle_interface/sd_logger.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_logger.h
@@ -1,0 +1,121 @@
+#ifndef SD_LOGGER
+#define SD_LOGGER
+
+#include "rclcpp/rclcpp.hpp"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
+
+void set_logger_level(const std::string& level, std::shared_ptr<rclcpp::Node> node)
+{
+    if(level == "debug")
+    {
+        node->get_logger().set_level(rclcpp::Logger::Level::Debug);
+    }
+    else if(level == "info")
+    {
+        node->get_logger().set_level(rclcpp::Logger::Level::Info);
+    }
+    else if(level == "warn")
+    {
+        node->get_logger().set_level(rclcpp::Logger::Level::Warn);
+    }
+    else if(level == "error")
+    {
+        node->get_logger().set_level(rclcpp::Logger::Level::Error);
+    }
+    else if(level == "fatal")
+    {
+        node->get_logger().set_level(rclcpp::Logger::Level::Fatal);
+    }
+}
+ 
+#define DEBUG(node, wait_ms, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_DEBUG_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), wait_ms, message); \
+        } \
+    } while(0) \
+
+#define DEBUG_COND(node, condition, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_DEBUG_STREAM_EXPRESSION(node->get_logger(), condition, message); \
+        } \
+    } while(0) \
+
+#define INFO(node, wait_ms, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_INFO_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), wait_ms, message); \
+        } \
+    } while(0) \
+
+#define INFO_COND(node, condition, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_INFO_STREAM_EXPRESSION(node->get_logger(), condition, message); \
+        } \
+    } while(0) \
+
+#define WARN(node, wait_ms, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_WARN_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), wait_ms, message); \
+        } \
+    } while(0) \
+
+#define WARN_COND(node, condition, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_WARN_STREAM_EXPRESSION(node->get_logger(), condition, message); \
+        } \
+    } while(0) \
+
+#define ERROR(node, wait_ms, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_ERROR_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), wait_ms, message); \
+        } \
+    } while(0) \
+
+#define ERROR_COND(node, condition, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_ERROR_STREAM_EXPRESSION(node->get_logger(), condition, message); \
+        } \
+    } while(0) \
+
+#define FATAL(node, wait_ms, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_FATAL_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), wait_ms, message); \
+        } \
+    } while(0) \
+
+#define FATAL_COND(node, condition, message) \
+    do \
+    { \
+        if(_sd_enable_logging) \
+        { \
+            RCLCPP_FATAL_STREAM_EXPRESSION(node->get_logger(), condition, message); \
+        } \
+    } while(0) \
+
+#endif

--- a/vehicle_interface/src/sd_vehicle_interface/sd_logger.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_logger.h
@@ -82,6 +82,15 @@ void set_logger_level(const std::string& level, std::shared_ptr<rclcpp::Node> no
         } \
     } while(0) \
 
+#define WARN_COND_THROTTLE(node, wait_ms, condition, message) \
+    do \
+    { \
+        if(_sd_enable_logging && (condition)) \
+        { \
+            RCLCPP_WARN_STREAM_THROTTLE(node->get_logger(), *node->get_clock(), wait_ms, message); \
+        } \
+    } while(0) \
+ 
 #define ERROR(node, wait_ms, message) \
     do \
     { \

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -47,8 +47,11 @@ using namespace std;
 #include "sd_lib_mcav.h"
 #include "sd_gps_imu.h"
 #include "sd_control.h"
+#include "rcl_interfaces/msg/set_parameters_result.hpp"
 
-bool isShowInfo = true;
+//boolean to toggle logging on and off. 
+bool enable_logging = true;
+
 
 //Callback Functions
 void ReceivedFrameCANRx_callback(const std::shared_ptr<can_msgs::msg::Frame> msg)
@@ -87,19 +90,21 @@ void CurrentVelocity_callback(const std::shared_ptr<geometry_msgs::msg::TwistSta
     CurrentTwistLinearNDT_Mps = msg->twist.linear.x; //mps to kph
 }
 
-#define LOGGING(nodeLogger, clock, duration, message) 					\
-if (isShowInfo)															\
-{																		\
-	RCLCPP_INFO_STREAM_THROTTLE(nodeLogger, clock, duration, message);	\
-}
+// This still currently only guard the LOGGING macro and not other ROS logs. 
+#define LOGGING(logger, clock, duration_ms, message) \
+  do { \
+    if (enable_logging) { \
+      RCLCPP_INFO_STREAM_THROTTLE(logger, clock, duration_ms, message); \
+    } \
+  } while (0)
 
-#define a 1+1
+
 
 int main(int argc, char **argv)
 {
 
 	rclcpp::init(argc, argv);
-    auto node = rclcpp::Node::make_shared("sd_twizy_interface_node");
+	auto node = rclcpp::Node::make_shared("sd_twizy_interface_node");
 	node->declare_parameter<std::string>("sd_vehicle", "env200");
 	_sd_vehicle = node->get_parameter("sd_vehicle").as_string();
 	node->declare_parameter<std::string>("sd_gps_imu", "oxts");
@@ -108,6 +113,35 @@ int main(int argc, char **argv)
 	_sd_speed_source = node->get_parameter("sd_speed_source").as_string();
 	node->declare_parameter<bool>("sd_simulation_mode", false);
 	_sd_simulation_mode = node->get_parameter("sd_simulation_mode").as_bool();
+
+	// Allow logging to be enabled/disabled at runtime through a ROS 2 parameter.
+	node->declare_parameter<bool>("enable_logging", true);
+	enable_logging = node->get_parameter("enable_logging").as_bool();
+
+	auto logging_param_callback_handle =
+		node->add_on_set_parameters_callback(
+			[](const std::vector<rclcpp::Parameter> & params)
+			{
+				rcl_interfaces::msg::SetParametersResult result;
+				result.successful = true;
+				result.reason = "";
+
+				for (const auto & param : params) {
+					if (param.get_name() == "enable_logging") {
+						if (param.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
+							result.successful = false;
+							result.reason = "enable_logging must be a bool";
+							return result;
+						}
+
+						enable_logging = param.as_bool();
+					}
+				}
+
+				return result;
+			});
+
+
 
 	//initialise the StreetDrone Output Can variables
 	sd::InitSDInterfaceControl(CustomerControlCANTx);
@@ -191,31 +225,27 @@ int main(int argc, char **argv)
 
 				// cout <<_sd_vehicle <<" TwistAngular " <<  setw(8) << TargeTireAngle_Rad << " Steer " <<  setw(8) << (int)FinalDBWSteerRequest_Pc << endl;
 				// cout << _sd_vehicle << " TwistLinear " <<  setw(8) <<TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Current_V "<<  setw(4)  << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Torque "<<  setw(2)  << (int)FinalDBWTorqueRequest_Pc << " P " <<  setw(2) << P_Contribution_Pc << " I " <<  setw(2) << I_Contribution_Pc << " D " <<  setw(2) << D_Contribution_Pc << " FF " <<  setw(2) << FF_Contribution_Pc << endl;
+				
+				// Logging function implementation.
 				LOGGING(node->get_logger(), *node->get_clock(), 1000,
 											_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad
 											<< " Steer " << setw(8) << (int)(FinalDBWSteerRequest_Pc));
-				LOGGING(node->get_logger(), *node->get_clock(), 1000, "dvito");
-				// RCLCPP_INFO_STREAM_THROTTLE(
-				// 							node->get_logger(), *node->get_clock(), 1000,
-				// 							_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad
-				// 										<< " Steer " << setw(8) << (int)FinalDBWSteerRequest_Pc);
+				
+				// Logging function implementation.
+				LOGGING(node->get_logger(), *node->get_clock(), 1000,
+        									_sd_vehicle << " TwistLinear " << setw(8) << TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR
+                    						<< " Current_V " << setw(4) << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR
+                    						<< " Torque " << setw(2) << (int)FinalDBWTorqueRequest_Pc
+                    						<< " P " << setw(2) << P_Contribution_Pc
+                    						<< " I " << setw(2) << I_Contribution_Pc
+                    						<< " D " << setw(2) << D_Contribution_Pc
+                    						<< " FF " << setw(2) << FF_Contribution_Pc);
 
-				// RCLCPP_INFO_STREAM_THROTTLE(
-				// 							node->get_logger(), *node->get_clock(), 1000,
-				// 							_sd_vehicle << " TwistLinear " << setw(8) << TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR
-				// 										<< " Current_V " << setw(4) << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR
-				// 										<< " Torque " << setw(2) << (int)FinalDBWTorqueRequest_Pc
-				// 										<< " P " << setw(2) << P_Contribution_Pc
-				// 										<< " I " << setw(2) << I_Contribution_Pc
-				// 										<< " D " << setw(2) << D_Contribution_Pc
-				// 										<< " FF " << setw(2) << FF_Contribution_Pc);
-				// 										SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
-				// 										SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
-				// 										sd_control_pub->publish(SD_Current_Control);
 
 				SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
 				SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
 				sd_control_pub->publish(SD_Current_Control);
+
 			}
 			
 			//Populate the Can frames with calculated data

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -48,9 +48,7 @@ using namespace std;
 #include "sd_gps_imu.h"
 #include "sd_control.h"
 #include "rcl_interfaces/msg/set_parameters_result.hpp"
-
-//boolean to toggle logging on and off. 
-bool enable_logging = true;
+#include "sd_logger.h"
 
 
 //Callback Functions
@@ -90,13 +88,6 @@ void CurrentVelocity_callback(const std::shared_ptr<geometry_msgs::msg::TwistSta
     CurrentTwistLinearNDT_Mps = msg->twist.linear.x; //mps to kph
 }
 
-// This still currently only guard the LOGGING macro and not other ROS logs. 
-#define LOGGING(logger, clock, duration_ms, message) \
-  do { \
-    if (enable_logging) { \
-      RCLCPP_INFO_STREAM_THROTTLE(logger, clock, duration_ms, message); \
-    } \
-  } while (0)
 
 
 
@@ -113,28 +104,39 @@ int main(int argc, char **argv)
 	_sd_speed_source = node->get_parameter("sd_speed_source").as_string();
 	node->declare_parameter<bool>("sd_simulation_mode", false);
 	_sd_simulation_mode = node->get_parameter("sd_simulation_mode").as_bool();
-
-	// Allow logging to be enabled/disabled at runtime through a ROS 2 parameter.
-	node->declare_parameter<bool>("enable_logging", true);
-	enable_logging = node->get_parameter("enable_logging").as_bool();
+	node->declare_parameter<bool>("sd_enable_logging", true);
+	_sd_enable_logging = node->get_parameter("sd_enable_logging").as_bool();
+	node->declare_parameter<std::string>("sd_logger_level", "debug");
+	set_logger_level(node->get_parameter("sd_logger_level").as_string(), node);
 
 	auto logging_param_callback_handle =
 		node->add_on_set_parameters_callback(
-			[](const std::vector<rclcpp::Parameter> & params)
+			[&node](const std::vector<rclcpp::Parameter> & params)
 			{
 				rcl_interfaces::msg::SetParametersResult result;
 				result.successful = true;
 				result.reason = "";
 
 				for (const auto & param : params) {
-					if (param.get_name() == "enable_logging") {
+					// Allow logging to be enabled/disabled at runtime through a ROS 2 parameter.
+					if (param.get_name() == "sd_enable_logging") {
 						if (param.get_type() != rclcpp::ParameterType::PARAMETER_BOOL) {
 							result.successful = false;
-							result.reason = "enable_logging must be a bool";
+							result.reason = "sd_enable_logging must be a bool";
 							return result;
 						}
 
-						enable_logging = param.as_bool();
+						_sd_enable_logging = param.as_bool();
+					}
+
+					if (param.get_name() == "sd_logger_level") {
+						if (param.get_type() != rclcpp::ParameterType::PARAMETER_STRING) {
+							result.successful = false;
+							result.reason = "sd_logger_level must be a string";
+							return result;
+						}
+
+						set_logger_level(param.as_string(), node);
 					}
 				}
 
@@ -225,21 +227,25 @@ int main(int argc, char **argv)
 
 				// cout <<_sd_vehicle <<" TwistAngular " <<  setw(8) << TargeTireAngle_Rad << " Steer " <<  setw(8) << (int)FinalDBWSteerRequest_Pc << endl;
 				// cout << _sd_vehicle << " TwistLinear " <<  setw(8) <<TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Current_V "<<  setw(4)  << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Torque "<<  setw(2)  << (int)FinalDBWTorqueRequest_Pc << " P " <<  setw(2) << P_Contribution_Pc << " I " <<  setw(2) << I_Contribution_Pc << " D " <<  setw(2) << D_Contribution_Pc << " FF " <<  setw(2) << FF_Contribution_Pc << endl;
-				
+
 				// Logging function implementation.
-				LOGGING(node->get_logger(), *node->get_clock(), 1000,
-											_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad
-											<< " Steer " << setw(8) << (int)(FinalDBWSteerRequest_Pc));
-				
+				INFO(node, 1000,
+								_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad
+								<< " Steer " << setw(8) << (int)(FinalDBWSteerRequest_Pc));
+
 				// Logging function implementation.
-				LOGGING(node->get_logger(), *node->get_clock(), 1000,
-        									_sd_vehicle << " TwistLinear " << setw(8) << TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR
-                    						<< " Current_V " << setw(4) << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR
-                    						<< " Torque " << setw(2) << (int)FinalDBWTorqueRequest_Pc
-                    						<< " P " << setw(2) << P_Contribution_Pc
-                    						<< " I " << setw(2) << I_Contribution_Pc
-                    						<< " D " << setw(2) << D_Contribution_Pc
-                    						<< " FF " << setw(2) << FF_Contribution_Pc);
+				INFO(node, 1000,
+								_sd_vehicle << " TwistLinear " << setw(8) << TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR
+								<< " Current_V " << setw(4) << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR
+								<< " Torque " << setw(2) << (int)FinalDBWTorqueRequest_Pc
+								<< " P " << setw(2) << P_Contribution_Pc
+								<< " I " << setw(2) << I_Contribution_Pc
+								<< " D " << setw(2) << D_Contribution_Pc
+								<< " FF " << setw(2) << FF_Contribution_Pc);
+
+				// Logging function implementation.
+				WARN_COND(node, CurrentTwistLinearCANSD_Mps*UNDO_STREETDRONE_SCALING_FACTOR < 0, 
+								"Somehow current velocity is negative!");
 
 
 				SD_Current_Control.steer = FinalDBWSteerRequest_Pc;

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -244,8 +244,12 @@ int main(int argc, char **argv)
 								<< " FF " << setw(2) << FF_Contribution_Pc);
 
 				// Logging function implementation.
-				WARN_COND(node, CurrentTwistLinearCANSD_Mps*UNDO_STREETDRONE_SCALING_FACTOR < 0, 
+				WARN_COND(node, TargetTwistLinear_Mps*UNDO_STREETDRONE_SCALING_FACTOR < 0, 
 								"Somehow current velocity is negative!");
+
+				// Logging function implementation.
+				WARN_COND(node, TargeTireAngle_Rad < 0, 
+								"Somehow angle is negative!");			
 
 
 				SD_Current_Control.steer = FinalDBWSteerRequest_Pc;

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -212,6 +212,10 @@ int main(int argc, char **argv)
 				// 										SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
 				// 										SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
 				// 										sd_control_pub->publish(SD_Current_Control);
+
+				SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
+				SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
+				sd_control_pub->publish(SD_Current_Control);
 			}
 			
 			//Populate the Can frames with calculated data

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -48,6 +48,8 @@ using namespace std;
 #include "sd_gps_imu.h"
 #include "sd_control.h"
 
+bool isShowInfo = true;
+
 //Callback Functions
 void ReceivedFrameCANRx_callback(const std::shared_ptr<can_msgs::msg::Frame> msg)
 {
@@ -84,6 +86,14 @@ void CurrentVelocity_callback(const std::shared_ptr<geometry_msgs::msg::TwistSta
 	//Current Velocity Reported from NDT
     CurrentTwistLinearNDT_Mps = msg->twist.linear.x; //mps to kph
 }
+
+#define LOGGING(nodeLogger, clock, duration, message) 					\
+if (isShowInfo)															\
+{																		\
+	RCLCPP_INFO_STREAM_THROTTLE(nodeLogger, clock, duration, message);	\
+}
+
+#define a 1+1
 
 int main(int argc, char **argv)
 {
@@ -181,10 +191,27 @@ int main(int argc, char **argv)
 
 				// cout <<_sd_vehicle <<" TwistAngular " <<  setw(8) << TargeTireAngle_Rad << " Steer " <<  setw(8) << (int)FinalDBWSteerRequest_Pc << endl;
 				// cout << _sd_vehicle << " TwistLinear " <<  setw(8) <<TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Current_V "<<  setw(4)  << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Torque "<<  setw(2)  << (int)FinalDBWTorqueRequest_Pc << " P " <<  setw(2) << P_Contribution_Pc << " I " <<  setw(2) << I_Contribution_Pc << " D " <<  setw(2) << D_Contribution_Pc << " FF " <<  setw(2) << FF_Contribution_Pc << endl;
-				SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
-				SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
-				sd_control_pub->publish(SD_Current_Control);
+				LOGGING(node->get_logger(), *node->get_clock(), 1000,
+											_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad
+											<< " Steer " << setw(8) << (int)(FinalDBWSteerRequest_Pc));
+				LOGGING(node->get_logger(), *node->get_clock(), 1000, "dvito");
+				// RCLCPP_INFO_STREAM_THROTTLE(
+				// 							node->get_logger(), *node->get_clock(), 1000,
+				// 							_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad
+				// 										<< " Steer " << setw(8) << (int)FinalDBWSteerRequest_Pc);
 
+				// RCLCPP_INFO_STREAM_THROTTLE(
+				// 							node->get_logger(), *node->get_clock(), 1000,
+				// 							_sd_vehicle << " TwistLinear " << setw(8) << TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR
+				// 										<< " Current_V " << setw(4) << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR
+				// 										<< " Torque " << setw(2) << (int)FinalDBWTorqueRequest_Pc
+				// 										<< " P " << setw(2) << P_Contribution_Pc
+				// 										<< " I " << setw(2) << I_Contribution_Pc
+				// 										<< " D " << setw(2) << D_Contribution_Pc
+				// 										<< " FF " << setw(2) << FF_Contribution_Pc);
+				// 										SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
+				// 										SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
+				// 										sd_control_pub->publish(SD_Current_Control);
 			}
 			
 			//Populate the Can frames with calculated data

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -88,9 +88,6 @@ void CurrentVelocity_callback(const std::shared_ptr<geometry_msgs::msg::TwistSta
     CurrentTwistLinearNDT_Mps = msg->twist.linear.x; //mps to kph
 }
 
-
-
-
 int main(int argc, char **argv)
 {
 
@@ -225,10 +222,6 @@ int main(int argc, char **argv)
 					FinalDBWTorqueRequest_Pc = speedcontroller::CalculateTorqueRequestEnv200(TargetTwistLinear_Mps, CurrentTwistLinearSD_Mps_Final, P_Contribution_Pc, I_Contribution_Pc, D_Contribution_Pc, FF_Contribution_Pc);
 				}
 				
-				// Old cout prints
-				// cout <<_sd_vehicle <<" TwistAngular " <<  setw(8) << TargeTireAngle_Rad << " Steer " <<  setw(8) << (int)FinalDBWSteerRequest_Pc << endl;
-				// cout << _sd_vehicle << " TwistLinear " <<  setw(8) <<TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Current_V "<<  setw(4)  << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Torque "<<  setw(2)  << (int)FinalDBWTorqueRequest_Pc << " P " <<  setw(2) << P_Contribution_Pc << " I " <<  setw(2) << I_Contribution_Pc << " D " <<  setw(2) << D_Contribution_Pc << " FF " <<  setw(2) << FF_Contribution_Pc << endl;
-
 				// Logging function implementation.
 				INFO(node, 1000,
 								_sd_vehicle << " TwistAngular " << setw(8) << TargeTireAngle_Rad

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.cpp
@@ -224,7 +224,8 @@ int main(int argc, char **argv)
 				}else{
 					FinalDBWTorqueRequest_Pc = speedcontroller::CalculateTorqueRequestEnv200(TargetTwistLinear_Mps, CurrentTwistLinearSD_Mps_Final, P_Contribution_Pc, I_Contribution_Pc, D_Contribution_Pc, FF_Contribution_Pc);
 				}
-
+				
+				// Old cout prints
 				// cout <<_sd_vehicle <<" TwistAngular " <<  setw(8) << TargeTireAngle_Rad << " Steer " <<  setw(8) << (int)FinalDBWSteerRequest_Pc << endl;
 				// cout << _sd_vehicle << " TwistLinear " <<  setw(8) <<TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Current_V "<<  setw(4)  << CurrentTwistLinearCANSD_Mps * UNDO_STREETDRONE_SCALING_FACTOR << " Torque "<<  setw(2)  << (int)FinalDBWTorqueRequest_Pc << " P " <<  setw(2) << P_Contribution_Pc << " I " <<  setw(2) << I_Contribution_Pc << " D " <<  setw(2) << D_Contribution_Pc << " FF " <<  setw(2) << FF_Contribution_Pc << endl;
 
@@ -243,18 +244,24 @@ int main(int argc, char **argv)
 								<< " D " << setw(2) << D_Contribution_Pc
 								<< " FF " << setw(2) << FF_Contribution_Pc);
 
-				// Logging function implementation.
-				WARN_COND(node, TargetTwistLinear_Mps*UNDO_STREETDRONE_SCALING_FACTOR < 0, 
-								"Somehow current velocity is negative!");
+						// Logging function implementation.
+						WARN_COND_THROTTLE(
+							node,
+							1000,
+							TargetTwistLinear_Mps * UNDO_STREETDRONE_SCALING_FACTOR < 0,
+							"Target velocity is negative!");
 
-				// Logging function implementation.
-				WARN_COND(node, TargeTireAngle_Rad < 0, 
-								"Somehow angle is negative!");			
+						// Logging function implementation.
+						WARN_COND_THROTTLE(
+							node,
+							1000,
+							(TargeTireAngle_Rad > MAX_STEER_ANG) || (TargeTireAngle_Rad < MIN_STEER_ANG),
+							"Target steering angle out of range MAX +-40°");
 
 
-				SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
-				SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
-				sd_control_pub->publish(SD_Current_Control);
+						SD_Current_Control.steer = FinalDBWSteerRequest_Pc;
+						SD_Current_Control.torque = FinalDBWTorqueRequest_Pc;
+						sd_control_pub->publish(SD_Current_Control);
 
 			}
 			

--- a/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_vehicle_interface.h
@@ -92,6 +92,7 @@ static string _sd_vehicle;
 static string _sd_gps_imu;
 static string _sd_speed_source; 
 static bool _sd_simulation_mode;
+static bool _sd_enable_logging;
 
 static string twizy_string = "twizy";
 


### PR DESCRIPTION
## Summary

Added logger functionality with multi level logging. Implemented inside `sd_vehile_interface.cpp`.  Added `sd_logger.h` where the logging macros are defined. Logger functionality can be toggled on/off and specific logging level viewing could also be set. 

## Changes
- Modified the cout print statement to implement logging for the vehicle telemetry.
- If user steering angle and velocity requested is out of bounds, there will be a WARN level log displayed.
- Modified the launch.xml file to support logging toggle. 
- Updated the README file to capture the logger functionality use.

## Testing 

Below is the output of when a user enters values out of bounds:
```
[sd_vehicle_interface_node-1] [WARN] [1775611960.682042081] [sd_vehicle_interface_node]: Target velocity is negative!
[sd_vehicle_interface_node-1] [WARN] [1775611960.781909041] [sd_vehicle_interface_node]: Target steering angle out of range MAX +-40°
[sd_vehicle_interface_node-1] [INFO] [1775611961.081827196] [sd_vehicle_interface_node]: twizy TwistAngular  -1.0472 Steer     -100
[sd_vehicle_interface_node-1] [INFO] [1775611961.081930717] [sd_vehicle_interface_node]: twizy TwistLinear      -10 Current_V    0 Torque  0 P  0 I  0 D  0 FF  0
[sd_vehicle_interface_node-1] [WARN] [1775611961.761863542] [sd_vehicle_interface_node]: Target velocity is negative!
[sd_vehicle_interface_node-1] [WARN] [1775611961.861869497] [sd_vehicle_interface_node]: Target steering angle out of range MAX +-40°
```

Input:
```
Enter speed: -10
Enter angle: -60
Published Control: speed=-10.0, angle=-60.0°
```