### PR TITLE
AutomationGranted_B

### DIFF
--- a/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
@@ -100,12 +100,12 @@ namespace sd{
 		// Check which kind of frame we have received and update data accordingly
 		if (frame.id == 0x100) { // StreetDrone_Control_1
 			bool steer_automation_available = frame.data[7] & 0x01; // bit 56 (0b0000 0001)
-			bool steer_automation_granted = frame.data[7] & 0x40; // bit 57 (0b0100 0000)
+			bool steer_automation_granted = frame.data[7] & 0x40; // bit 57 (0b0000 0010)
 			bool torque_automation_available = frame.data[7] & 0x10; // bit 60 (0b0001 0000)
-			bool torque_automation_granted = frame.data[7] & 0x4; // bit 61 (0b0000 0100)
+			bool torque_automation_granted = frame.data[7] & 0x4; // bit 61 (0b0010 0000)
 			AutomationArmed_B = steer_automation_available && torque_automation_available;
 			AutomationGranted_B = steer_automation_granted && torque_automation_granted;
-			AutomationGranted_B = frame.data[7] & 0b00100010;
+			// AutomationGranted_B = frame.data[7] & 0b00100010;
 		} else if (frame.id == 0x102) { // StreetDrone_Data_1
 			//Speed is 16bit, and .data is 8bit, the below processing fuses speed into a single 16bit variable. The /100 divider handles the signal resolution
 			uint8_t CurrentVelocity8bit = frame.data[0]; //Speed Actual kph low resolution

--- a/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
@@ -99,10 +99,10 @@ namespace sd{
     void ParseRxCANDataSDCan(can_msgs::msg::Frame& frame, double& CurrentLinearVelocity_Mps, bool& AutomationArmed_B, bool& AutomationGranted_B) {
 		// Check which kind of frame we have received and update data accordingly
 		if (frame.id == 0x100) { // StreetDrone_Control_1
-			bool steer_automation_available = frame.data[7] & 0b00000001; // bit 56 (0b0000 0001)
-			bool steer_automation_granted = frame.data[7] & 0b00000010; // bit 57 (0b0000 0010)
-			bool torque_automation_available = frame.data[7] & 0b00010000; // bit 60 (0b0001 0000)
-			bool torque_automation_granted = frame.data[7] & 0b00100000; // bit 61 (0b0010 0000)
+			bool steer_automation_available = frame.data[7] & 0b0000'0001; // bit 56
+			bool steer_automation_granted = frame.data[7] & 0b0000'0010; // bit 57
+			bool torque_automation_available = frame.data[7] & 0b0001'0000; // bit 60
+			bool torque_automation_granted = frame.data[7] & 0b0010'0000; // bit 61
 			AutomationArmed_B = steer_automation_available && torque_automation_available;
 			AutomationGranted_B = steer_automation_granted && torque_automation_granted;
 		} else if (frame.id == 0x102) { // StreetDrone_Data_1

--- a/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
@@ -99,10 +99,10 @@ namespace sd{
     void ParseRxCANDataSDCan(can_msgs::msg::Frame& frame, double& CurrentLinearVelocity_Mps, bool& AutomationArmed_B, bool& AutomationGranted_B) {
 		// Check which kind of frame we have received and update data accordingly
 		if (frame.id == 0x100) { // StreetDrone_Control_1
-			bool steer_automation_available = frame.data[7] & 0x01; // bit 56 (0b0000 0001)
-			bool steer_automation_granted = frame.data[7] & 0x40; // bit 57 (0b0000 0010)
-			bool torque_automation_available = frame.data[7] & 0x10; // bit 60 (0b0001 0000)
-			bool torque_automation_granted = frame.data[7] & 0x4; // bit 61 (0b0010 0000)
+			bool steer_automation_available = frame.data[7] & 0b00000001; // bit 56 (0b0000 0001)
+			bool steer_automation_granted = frame.data[7] & 0b00000010; // bit 57 (0b0000 0010)
+			bool torque_automation_available = frame.data[7] & 0b00010000; // bit 60 (0b0001 0000)
+			bool torque_automation_granted = frame.data[7] & 0b00100000; // bit 61 (0b0010 0000)
 			AutomationArmed_B = steer_automation_available && torque_automation_available;
 			AutomationGranted_B = steer_automation_granted && torque_automation_granted;
 			// AutomationGranted_B = frame.data[7] & 0b00100010;

--- a/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
+++ b/vehicle_interface/src/sd_vehicle_interface/sd_lib_mcav.h
@@ -105,7 +105,6 @@ namespace sd{
 			bool torque_automation_granted = frame.data[7] & 0b00100000; // bit 61 (0b0010 0000)
 			AutomationArmed_B = steer_automation_available && torque_automation_available;
 			AutomationGranted_B = steer_automation_granted && torque_automation_granted;
-			// AutomationGranted_B = frame.data[7] & 0b00100010;
 		} else if (frame.id == 0x102) { // StreetDrone_Data_1
 			//Speed is 16bit, and .data is 8bit, the below processing fuses speed into a single 16bit variable. The /100 divider handles the signal resolution
 			uint8_t CurrentVelocity8bit = frame.data[0]; //Speed Actual kph low resolution


### PR DESCRIPTION
## Summary
- fix the bitmask check for steering and torque grant based on `StreetDrone_Control_1` bit mappings
- use binary representation for bitmask check and remove from comments
- removes the redundant `AutomationGranted_B` reassignment line so grant state is determined by the steer+torque granted checks only

## Test 
Tested on the twizy to ensure automation is still granted when requested